### PR TITLE
Gestione codici fiscali omocodici

### DIFF
--- a/AgID_Vocabularies/AgID_basic_components-1.0.0.xsd
+++ b/AgID_Vocabularies/AgID_basic_components-1.0.0.xsd
@@ -44,7 +44,7 @@
     
     <xs:simpleType name="CodiceFiscaleType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z]{6}[0-9]{2}[ABCDEHLMPRST][0-9]{2}[A-Z][0-9]{3}[A-Z]"/>
+            <xs:pattern value="[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]"/>
         </xs:restriction>
     </xs:simpleType>
     


### PR DESCRIPTION
Può accadere che due o più persone possano avere dati anagrafici tali da generare lo stesso codice fiscale (omocodici). In questi casi, l’Agenzia delle Entrate provvede ad attribuire a ciascuna di esse un nuovo codice fiscale, calcolato, a partire da quello generato in base ai dati anagrafici, sostituendo i soli caratteri numerici (a partire da quello più a destra) con una lettera, secondo la seguente corrispondenza:
0 --> L
1 --> M
2 --> N
3 --> P
4 --> Q
5 --> R
6 --> S
7 --> T
8 --> U
9 --> V